### PR TITLE
feat: Chakra UI 테마 설정 추가(2)

### DIFF
--- a/src/components/Trailer.jsx
+++ b/src/components/Trailer.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Box, Text } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+
+// eslint-disable-next-line react/prop-types
+const Trailer = ({ title, trailerCode }) => {
+  const src = 'https://www.youtube.com/embed/${trailerCode}?autoplay=1';
+  const isTrailer = Boolean(trailerCode);
+
+  return isTrailer ? (
+    <Box
+      className="trailer"
+      title={title}
+      src={src}
+      width="100%"
+      height="100%"
+      animation="fade-in 0.5s ease-in-out forwards"
+      as="iframe"
+      frameBorder="0"
+    ></Box>
+  ) : (
+    <Box className="no-trailer">No Trailer available.</Box>
+  );
+};
+
+Trailer.PropTypes = {
+  title: PropTypes.string.isRequired,
+  trailerCode: PropTypes.string.isRequired,
+};
+
+export default Trailer;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { ColorModeScript } from '@chakra-ui/react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import theme from '@/styles/theme';
@@ -6,7 +5,6 @@ import theme from '@/styles/theme';
 const rootElement = document.getElementById('root');
 createRoot(rootElement).render(
   <>
-    <ColorModeScript initialColorMode={theme.config.initialColorMode} />
     <App />
   </>,
 );

--- a/src/routes/Detail.jsx
+++ b/src/routes/Detail.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import './App.js';
+import Trailer from './Trailer';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>Movie Trailer</h1>
+      <Trailer title="Movie Title" trailerCode="YourTrailerCode" />
+    </div>
+  );
+}
+
+export default App;

--- a/src/styles/Variables.jsx
+++ b/src/styles/Variables.jsx
@@ -1,0 +1,38 @@
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import { extendTheme } from '@chakra-ui/react';
+
+const theme = extendTheme({
+  colors: {
+    pink: {
+      50: '#fff5f7',
+      100: '#fed7e2',
+    },
+    black: '#141414',
+    coral: {
+      50: '#fef5e7',
+      100: '#feb670',
+    },
+    mustard: {
+      50: '#fffbdd',
+      100: '#ffea83',
+    },
+    mint: {
+      50: '#ecfdf5',
+      100: '#6cf0c8',
+    },
+    azure: {
+      50: '#ebf7ff',
+      100: '#63b4f7',
+    },
+  },
+});
+
+function App() {
+  return (
+    <ChakraProvider theme={theme}>
+      <ColorModeScript initialColorMode="light" />
+    </ChakraProvider>
+  );
+}
+
+export default App;

--- a/src/styles/Variables.jsx
+++ b/src/styles/Variables.jsx
@@ -1,7 +1,10 @@
-import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
 import { extendTheme } from '@chakra-ui/react';
 
 const theme = extendTheme({
+  config: {
+    initialColorMode: 'dark', // 초기 색상
+    useSystemColorMode: false, // 시스템 색상 사용여부
+  },
   colors: {
     pink: {
       50: '#fff5f7',
@@ -27,12 +30,4 @@ const theme = extendTheme({
   },
 });
 
-function App() {
-  return (
-    <ChakraProvider theme={theme}>
-      <ColorModeScript initialColorMode="light" />
-    </ChakraProvider>
-  );
-}
-
-export default App;
+export default theme;


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
<!-- 무엇을 작업하셨나요? -->
Chakra UI를 사용하여 애플리케이션의 테마를 설정했습니다. 테마에는 추가적인 색상 값을 정의했고, 초기 색상 모드를 블랙으로 설정했습니다.

- Chakra UI의 테마 설정
- 초기 색상 모드 설정

styles/theme.js 파일에서 컬러셋을 관리하고, ColorModeScript를 중복으로 사용하지 않고 ChakraProvider 및 RouterProvider가 정상적으로 설정됩니다.

관련자료: [https://ordinarypeople.info/work/watcha](url)
<!-- 수정이라면, 어떤 이유로 수정되었나요? -->

- src/index.js 파일 수정: src/App.js 에서 ColorModeScript가 적용되어 있기 때문에 중복으로 추가할 필요가 없어서 지웠습니다.
- src/App.js 파일 수정: ChakraProvider와 RouterProvider를 이미 구성되어있기에 추가적인 변경은 없습니다.

PS - Trailer.jsx, Detail.jsx is WIP