### PR TITLE
feat: chakra-variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { ColorModeScript } from '@chakra-ui/react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import theme from '@/styles/theme';
@@ -6,7 +5,6 @@ import theme from '@/styles/theme';
 const rootElement = document.getElementById('root');
 createRoot(rootElement).render(
   <>
-    <ColorModeScript initialColorMode={theme.config.initialColorMode} />
     <App />
   </>,
 );

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,9 +1,13 @@
 import { extendTheme } from '@chakra-ui/react';
 
-const config = {
-  initialColorMode: 'dark',
-  useSystemColorMode: false,
+const colors = {
+  pink: {
+    primary: '#fe0559',
+    secondary: '#ff7471',
+  },
+  black: '#000000',
+  white: '#ffffff',
 };
 
-const theme = extendTheme({ config });
+const theme = extendTheme({ config, colors });
 export default theme;


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
<!-- 무엇을 작업하셨나요? -->
<!-- 수정이라면, 어떤 이유로 수정되었나요? -->
Chakra UI를 사용하여 애플리케이션의 테마를 설정했습니다. 테마에는 추가적인 색상 값을 정의했고, 초기 색상 모드를 블랙으로 설정했습니다.

- Chakra UI의 테마 설정
- 초기 색상 모드 설정

styles/theme.js 파일에서 컬러셋을 관리하고, ColorModeScript를 중복으로 사용하지 않고 ChakraProvider 및 RouterProvider가 정상적으로 설정됩니다.

[WATCH-COLORSET](https://ordinarypeople.info/work/watcha)