### PR TITLE
feat: 스크롤바 스타일링 추가

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -28,6 +28,17 @@ const theme = extendTheme({
         width: '100%',
         height: '100vh',
       },
+      '::-webkit-scrollbar': {
+        w: '0.15rem',
+        backgroundColor: 'black',
+      },
+      '::-webkit-scrollbar-thumb': {
+        backgroundColor: 'pink.primary',
+        borderRadius: '1.4rem',
+      },
+      '*': {
+        scrollbarColor: 'pink.primary',
+      },
     },
   },
 });

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -23,21 +23,28 @@ const theme = extendTheme({
   },
   styles: {
     global: {
-      'html, body': {
-        backgroundColor: 'black',
+      html: {
         width: '100%',
         height: '100vh',
       },
-      '::-webkit-scrollbar': {
-        w: '0.15rem',
+      body: {
+        width: '100%',
+        height: '100%',
         backgroundColor: 'black',
       },
-      '::-webkit-scrollbar-thumb': {
-        backgroundColor: 'pink.primary',
-        borderRadius: '1.4rem',
+      '#root': {
+        width: '100%',
+        height: '100%',
+        scrollbarGutter: 'stable',
+        overflow: 'auto',
       },
-      '*': {
-        scrollbarColor: 'pink.primary',
+      '::-webkit-scrollbar': {
+        width: '0.25rem',
+        backgroundColor: 'transparent',
+      },
+      '::-webkit-scrollbar-thumb': {
+        borderRadius: '4px',
+        backgroundColor: 'pink.primary',
       },
     },
   },


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
<!-- 무엇을 작업하셨나요? -->
<!-- 수정이라면, 어떤 이유로 수정되었나요? -->
**스크롤바 스타일링**
 
- 웹 페이지의 스크롤바를 개선하기 위해 커스텀 스타일을 적용했습니다.
- '::-webkit-scrollbar'를 사용하여 스크롤바의 너비를 조정하고 배경색을 검은색으로 설정했습니다.
- '::-webkit-scrollbar-thumb'를 사용하여 스크롤바 썸의 배경색을 'pink.primary'로 지정하고, 썸의 모서리를 둥글게 만들기 위해 'borderRadius'를 설정했습니다.
- '*' 선택자를 사용하여 페이지 내의 모든 스크롤바의 색상을 'pink.primary'로 설정했습니다.

<img width="1470" alt="image" src="https://github.com/geezers-io/front-beginners/assets/105610041/40d65074-d87c-48da-9b62-74d54102826d">
